### PR TITLE
BUG: Prevent malformed WAV from being written for edge case.

### DIFF
--- a/main_denoising.py
+++ b/main_denoising.py
@@ -204,6 +204,7 @@ def denoise_wav(src_wav_file, dest_wav_file, global_mean, global_var, use_gpu,
             data_se.append(wave_recon)
         finally:
             shutil.rmtree(tmp_dir)
+    data_se = [x.astype(np.int16, copy=False) for x in data_se]
     data_se = np.concatenate(data_se)
     wav_io.write(dest_wav_file, SR, data_se)
 


### PR DESCRIPTION
Fixes an edge case where malformed WAV would be produced if the last processed chunk was too short to apply the model.